### PR TITLE
fix: add new strings from Flutter 3.38

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -99,26 +99,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -147,10 +147,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -208,18 +208,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -229,5 +229,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.8.0-0 <4.0.0"
+  flutter: ">=3.38.1"

--- a/lib/src/cupertino.dart
+++ b/lib/src/cupertino.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
-
-import 'package:intl/intl.dart' as intl;
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
 
-import 'utils/date_localization.dart' as util;
 import 'delegates.dart';
+import 'utils/date_localization.dart' as util;
 
 /// The translations for Haitian Creole (`ht`).
 class CupertinoLocalizationHt extends GlobalCupertinoLocalizations {
@@ -180,6 +179,24 @@ class CupertinoLocalizationHt extends GlobalCupertinoLocalizations {
 
   @override
   String get shareButtonLabel => 'Pataje';
+
+  @override
+  String get collapsedHint => 'Depliye';
+
+  @override
+  String get expandedHint => 'Pliye';
+
+  @override
+  String get expansionTileCollapsedHint => 'Klike de fwa pou depliye';
+
+  @override
+  String get expansionTileCollapsedTapHint => 'Depliye pou plis detay';
+
+  @override
+  String get expansionTileExpandedHint => 'Klike de fwa pou pliye';
+
+  @override
+  String get expansionTileExpandedTapHint => 'Pliye';
 }
 
 class _CupertinoLocalizationHtDelegate

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/midsonlajeanty/ht_localization
 
 environment:
   sdk: ">=3.0.3 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
The new Flutter version added some new strings to cupertino localizations, so I added them to the `CupertinoLocalizationHt` class.